### PR TITLE
Moved js coded to separate file

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -5,26 +5,8 @@
 {% endblock %}
 
 {% block main %}
-<script>
-$(function() {
-
-    // Generate array from pythone list of lists
-    var item_bin_array = [
-        {% for entry in bin_list %}
-        {label:"{{ entry[0] }}", idx:"{{ entry[1] }}" },
-        {% endfor %}
-    ];
-
-    // Autocompleate form with filing out location field
-    $( "#part_number" ).autocomplete({
-        source: item_bin_array,
-        select: function(event, ui) { $('#location').val(ui.item.idx) ; }
-    });
-});
-</script>
 
 <h2>Generate Inventory Label</h2>
-
 
 <div class="container mt-4">
     <form method="POST" action="/generate-label" target="_blank">

--- a/templates/js/java-script.js
+++ b/templates/js/java-script.js
@@ -1,15 +1,19 @@
 $(function() {
 
-    // Generate array from pythone list of lists
+    // https://stackoverflow.com/questions/7177029/getting-the-index-of-the-selected-item-in-jquery-auto-complete
+    // https://api.jqueryui.com/autocomplete/#option-source
+
+    // Generate array from Python list of lists
+    // label -> item_pn; value -> location
     var item_bin_array = [
         {% for entry in bin_list %}
-        {label:"{{ entry[0] }}", idx:"{{ entry[1] }}" },
+        {label:"{{ entry[0] }}", value:"{{ entry[1] }}" },
         {% endfor %}
     ];
 
-    // Autocompleate form with filing out location field
+    // Autocomplete form with filing out location field
     $( "#part_number" ).autocomplete({
         source: item_bin_array,
-        select: function(event, ui) { $('#location').val(ui.item.idx) ; }
+        select: function(event, ui) { $('#location').val(ui.item.value) ; }
     });
 });

--- a/templates/js/java-script.js
+++ b/templates/js/java-script.js
@@ -1,0 +1,15 @@
+$(function() {
+
+    // Generate array from pythone list of lists
+    var item_bin_array = [
+        {% for entry in bin_list %}
+        {label:"{{ entry[0] }}", idx:"{{ entry[1] }}" },
+        {% endfor %}
+    ];
+
+    // Autocompleate form with filing out location field
+    $( "#part_number" ).autocomplete({
+        source: item_bin_array,
+        select: function(event, ui) { $('#location').val(ui.item.idx) ; }
+    });
+});

--- a/templates/js/java-script.js
+++ b/templates/js/java-script.js
@@ -4,16 +4,16 @@ $(function() {
     // https://api.jqueryui.com/autocomplete/#option-source
 
     // Generate array from Python list of lists
-    // label -> item_pn; value -> location
+    // label -> item_pn; idx -> location
     var item_bin_array = [
         {% for entry in bin_list %}
-        {label:"{{ entry[0] }}", value:"{{ entry[1] }}" },
+        {label:"{{ entry[0] }}", idx:"{{ entry[1] }}" },
         {% endfor %}
     ];
 
     // Autocomplete form with filing out location field
     $( "#part_number" ).autocomplete({
         source: item_bin_array,
-        select: function(event, ui) { $('#location').val(ui.item.value) ; }
+        select: function(event, ui) { $('#location').val(ui.item.idx) ; }
     });
 });

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -26,6 +26,8 @@
         <link href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/themes/ui-lightness/jquery-ui.css" rel="stylesheet" type="text/css" />
         <!-- --------------------------------------------------------------- -->
 
+        <!--         https://stackoverflow.com/questions/27917471/how-can-i-pass-parameter-through-serialization-and-then-parse-them-using-externa -->
+        <script>{% include 'js/java-script.js' %}</script>
 
         <title>INVENTORY {% block title %}{% endblock %}</title>
 


### PR DESCRIPTION
Moved autocomplete code to a separate file.
The `include` tag is used to load the file. The file is located in the templates/js folder, per suggestion from the link below 

[https://stackoverflow.com/questions/27917471/how-can-i-pass-parameter-through-serialization-and-then-parse-them-using-externa](https://stackoverflow.com/questions/27917471/how-can-i-pass-parameter-through-serialization-and-then-parse-them-using-externa)